### PR TITLE
fix: stop g_hardcore being set to 1 on boot

### DIFF
--- a/src/client/component/dedicated.cpp
+++ b/src/client/component/dedicated.cpp
@@ -307,6 +307,7 @@ namespace dedicated
 			utils::hook::set<uint32_t>(0x140B21137 + 2, 0x480); // g_hardcore flags
 			utils::hook::jump(0x140C12400, sv_get_game_type_stub);
 			utils::hook::jump(0x140C12660, sv_is_hardcore_mode_stub);
+			utils::hook::nop(0x140B20905, 5); // Stop g_hardcore being set to 1
 
 			utils::hook::nop(0x140CDD5D3, 5); // don't load config file
 			utils::hook::nop(0x140B7CE46, 5); // ^


### PR DESCRIPTION
For some reason in what looks like arxan mem space - g_hardcore gets set to 1 even if the server config is setting it to 0

This patches the call to Dvar_SetBool