### PR TITLE
fix: ensure error_popmenu is in the stack

### DIFF
--- a/data/cdata/ui_scripts/Lobby/__init__.lua
+++ b/data/cdata/ui_scripts/Lobby/__init__.lua
@@ -55,6 +55,8 @@ require("GameSetupButtonsBots")
 -- Fix issue with LobbyMission being rendered when error message is shown
 local orig_HandleErrors = LUI.UIRoot.HandleErrors
 LUI.UIRoot.HandleErrors = function(f16_arg0)
-    LUI.FlowManager.RequestLeaveMenuByName("LobbyMission", true)
     orig_HandleErrors(f16_arg0)
+    if LUI.FlowManager.IsInStack("error_popmenu") then
+        LUI.FlowManager.RequestLeaveMenuByName("LobbyMission", true)
+    end
 end


### PR DESCRIPTION
Ensure error_popmenu is on the stack before requesting to leave LobbyMission menu

Fixes issue with combat training not working as intended