### PR TITLE
dlog debug prints

### DIFF
--- a/src/client/game/dvars.cpp
+++ b/src/client/game/dvars.cpp
@@ -42,6 +42,7 @@ namespace dvars
 
 	game::dvar_t* logfile = nullptr;
 	game::dvar_t* g_log = nullptr;
+	game::dvar_t* dlog_enabled = nullptr;
 
 	game::dvar_t* jump_enableFallDamage = nullptr;
 

--- a/src/client/game/dvars.hpp
+++ b/src/client/game/dvars.hpp
@@ -39,6 +39,7 @@ namespace dvars
 
 	extern game::dvar_t* logfile;
 	extern game::dvar_t* g_log;
+	extern game::dvar_t* dlog_enabled;
 
 	extern game::dvar_t* jump_enableFallDamage;
 

--- a/src/client/game/game.cpp
+++ b/src/client/game/game.cpp
@@ -232,7 +232,7 @@ namespace game
 
 	void G_LogPrintf(const char* fmt, ...)
 	{
-		if (!dvars::logfile->current.enabled)
+		if (!dvars::g_log || !dvars::logfile || !dvars::logfile->current.enabled)
 		{
 			return;
 		}


### PR DESCRIPTION
- hooks into dlog for more debug info. can be enabled with the `dlog_enabled` dvar.