### PR TITLE
fix: only set tag if it has a value

### DIFF
--- a/src/client/component/auth.cpp
+++ b/src/client/component/auth.cpp
@@ -177,16 +177,15 @@ namespace auth
 
 			utils::info_string info_string{ std::string{params[2]} };
 
-			//char xuidStr[32]{};
-			//std::uint64_t xuid = steam::SteamUser()->GetSteamID().bits;
-			//game::XUIDToString(&xuid, xuidStr);
-			//info_string.set("xuid", xuidStr);
-
 			game::dvar_t* password = game::Dvar_FindVar("password");
 			info_string.set("password", password && password->current.string && password->current.string[0] != '\0' ? 
 				password->current.string : "0");
 
-			info_string.set("clanAbbrev", game::GamerProfile_GetClanName(0));
+			auto clanAbbrev = game::GamerProfile_GetClanName(0);
+			if (clanAbbrev && *clanAbbrev)
+			{
+				info_string.set("clanAbbrev", clanAbbrev);
+			}
 
 			connect_string.clear();
 			connect_string.append(params[0]);


### PR DESCRIPTION
Don't add clanAbbrev to info_string if there is no tag set

This caused an issue in combat training where clanAbbrev was reading invalid memory and causing the infostring to have invalid chars in it. This caused the name to become "badinfo"